### PR TITLE
Fails on Unbuntu with Syntax error

### DIFF
--- a/aws-blocker
+++ b/aws-blocker
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # Create the AWS iptables chain if it doesn't exist
 iptables -n --list AWS >/dev/null 2>&1 \


### PR DESCRIPTION
On Ubuntu the default shell is /bin/dash not /bin/bash so the shell doesn't support bash <<< redirection.  You get the following error:

 ./aws-blocker: Syntax error: redirection unexpected

The proper hash bang syntax was incorrect causing it to execute in /bin/dash instead of/bin/bash.  Added the #! at the top.
