### PR TITLE
Fix a typo and file loading, add ferm output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You'll need *jq* to parse the JSON. This package is readily available in most Li
 ## Usage
 
 ```
-Usage: aws-blocker [POSITION] [REGIONS]...
+aws-blocker [FILE] [POSITION] [REGIONS…]
 ```
 
 Position is a nummeric value specifying the line number the INPUT chain target line will be inserted at. Defaults to 1.
@@ -24,8 +24,8 @@ aws-blocker 3 ap-southeast sa-east
 ```
 
 
-Instead of downloading a file on each run you can also redirect a file input:
+Instead of downloading a file on each run you can also use an already existing file:
 
 ```
-aws-blocker < ranges.json
+aws-blocker ranges.json 4 sa-east
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ This simple bash script will retrieve the official list of AWS IPv4 and IPv6 ran
 
 The script is safe to run multiple times. The AWS IP range list is updated periodically, so you may want to run this script as a cron.
 
+
 ## Requirements
 
 You'll need *jq* to parse the JSON. This package is readily available in most Linux package managers.
 
+
 ## Usage
+
+
+### aws-blocker
 
 ```
 aws-blocker [FILE] [POSITION] [REGIONS…]
@@ -29,3 +34,13 @@ Instead of downloading a file on each run you can also use an already existing f
 ```
 aws-blocker ranges.json 4 sa-east
 ```
+
+
+### aws-blocker-ferm
+
+```
+aws-blocker-ferm [--file=FILE] [--filters=REGIONS…]
+```
+
+Outputs a ferm IP array for v4 and v6.
+Use `--help` for a description of all parameters.

--- a/aws-blocker
+++ b/aws-blocker
@@ -9,18 +9,6 @@
 # without quotes. We only need the list of prefixes, so we discard everything
 # else.
 
-POSITION=1
-FILTERS=""
-JSON_URL="https://ip-ranges.amazonaws.com/ip-ranges.json"
-
-
-# Get the line where the jump will be inserted at.
-# Useful if you want e.g related / established rules for outgoing traffic.
-if [[ -n $1 ]]; then
-    POSITION=$1
-    shift
-fi
-
 
 ##
 # Builds region filters based on CLI arguments
@@ -117,13 +105,34 @@ function add_iptables_rules() {
 
 
 
+
+POSITION=1
+FILTERS=""
+JSON_URL="https://ip-ranges.amazonaws.com/ip-ranges.json"
+
 # Retrieve IP ranges definition
 # Either from an URL or file input (e.g. "< ranges.json")
-if [ ! -t 0 ]; then
-    JSON=$(cat - <&0)
+if [[ -f $1 ]]; then
+    JSON=$(<$1)
+    shift
 else
     JSON=$(curl -s -L $JSON_URL)
 fi
+
+if [[ -z $JSON ]]; then
+    echo "JSON definition empty" >&2
+    exit 1
+fi
+
+
+# Get the line where the jump will be inserted at.
+# Useful if you want e.g related / established rules for outgoing traffic.
+if [[ -n $1 ]]; then
+    POSITION=$1
+    shift
+fi
+
+
 
 FILTERS=$(build_filters "$*")
 

--- a/aws-blocker
+++ b/aws-blocker
@@ -138,12 +138,12 @@ FILTERS=$(build_filters "$*")
 
 
 # IPv4
-create_and_flush_chain "" $position
+create_and_flush_chain "" $POSITION
 V4_RANGES=$(extract_ip_ranges "$JSON" "$FILTERS" "prefixes" "ip_prefix")
 add_iptables_rules ""  "$V4_RANGES"
 
 
 # IPv6
-create_and_flush_chain 6 $position
+create_and_flush_chain 6 $POSITION
 V6_RANGES=$(extract_ip_ranges "$JSON" "$FILTERS" "ipv6_prefixes" "ipv6_prefix")
 add_iptables_rules "6" "$V6_RANGES"

--- a/aws-blocker
+++ b/aws-blocker
@@ -9,119 +9,15 @@
 # without quotes. We only need the list of prefixes, so we discard everything
 # else.
 
-
-##
-# Builds region filters based on CLI arguments
-#
-# Arguments: CLI arguments as passed by $*
-#
-function build_filters() {
-    for arg in ${@:1}; do
-        if [[ -n $filters ]]; then
-            filters=$filters", "
-        fi
-
-        filters=$filters"select(.region | contains(\"$arg\"))"
-    done
-
-    if [[ -n $filters ]]; then
-        filters=" | "$filters
-    fi
-
-    echo $filters
-}
-
-
-##
-# Extracts IP ranges from an Amazon JSON file
-#
-# Arguments:
-#     $1 AWS JSON content
-#     $2 Prepared filter string
-#     $3 Group to extract IP ranges from (e.g. prefixes)
-#     $4 Object key for IP ranges (e.g ip_prefix)
-#
-function extract_ip_ranges() {
-    local json=$1
-    local filters=$2
-    local array=$3
-    local prefix=$4
-
-    local group='group_by(.'$prefix')'
-    local map='map({ "ip": .[0].'$prefix', "regions": map(.region) | unique, "services": map(.service) | unique })'
-
-    local to_string='.ip + " \"" + (.regions | sort | join (", ")) + "\" \"" + (.services | sort | join (", ")) + "\""'
-    local process='[ .'$array"[]$filters ] | $group | $map | .[] | $to_string"
-
-    local ranges=$(echo "$json" | jq -r "$process" | sort -Vu)
-    echo "$ranges"
-}
-
-
-##
-# Creates the AWS iptables chain if it doesn't exist, then flushes it
-#
-# Arguments:
-#     $1 Version to use. Omit for v4
-#     $2 Position to insert chain statement at
-#
-function create_and_flush_chain() {
-    local version=$1
-    local position=$2
-    local cmd=ip${version}tables
-
-    $cmd -n --list AWS >/dev/null 2>&1 \
-        || ($cmd -N AWS && $cmd -I INPUT $position -j AWS)
-
-    $cmd -F AWS
-}
-
-
-##
-# Adds an iptables rule for each line in ranges
-#
-# Arguments:
-#     $1 Version to use. Omit for v4
-#     $2 Prepared lines
-#
-function add_iptables_rules() {
-    local version=$1
-    local cmd=ip${version}tables
-    local lines
-    local data
-
-    IFS=$'\n' lines=($2)
-    unset IFS
-
-    for line in "${lines[@]}"; do
-        eval local data=($line)
-        local ip=${data[0]}
-        local regions=$(echo ${data[1]} | tr '[:upper:]' '[:lower:]')
-        local services=$(echo ${data[2]} | tr '[:upper:]' '[:lower:]')
-
-        $cmd -A AWS -s "$ip" -j REJECT -m comment --comment "$regions = $services"
-    done
-}
+DIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+. $DIR/functions.sh
 
 
 
+JSON=$(get_aws_json $1)
 
-POSITION=1
-FILTERS=""
-JSON_URL="https://ip-ranges.amazonaws.com/ip-ranges.json"
-
-# Retrieve IP ranges definition
-# Either from an URL or file input (e.g. "< ranges.json")
 if [[ -f $1 ]]; then
-    JSON=$(<$1)
     shift
-else
-    JSON=$(curl -s -L $JSON_URL)
-fi
-
-if [[ -z $JSON ]]; then
-    echo "JSON definition empty" >&2
-    exit 1
 fi
 
 
@@ -130,8 +26,11 @@ fi
 if [[ -n $1 ]]; then
     POSITION=$1
     shift
+else
+    POSITION=1
 fi
 
+log "Inserting at position $POSITION"
 
 
 FILTERS=$(build_filters "$*")

--- a/aws-blocker-ferm
+++ b/aws-blocker-ferm
@@ -1,0 +1,74 @@
+#!/bin/bash -e
+#
+# Creates a ferm IP array for Amazon AWS blocking.
+
+DIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+. $DIR/functions.sh
+
+
+function print_help() {
+    echo "$0"
+    echo "  --file     JSON definition file to load. Defaults to downloading it from Amazon."
+    echo "  --filters  Sets region filters (space separated, e.g. \"us-east-1 us-east-2\"')."
+    echo "  --debug    Prints debug output."
+    echo "  --help     Shows this help."
+}
+
+
+FILE=""
+FILTERS=""
+
+
+ARGS=$(getopt -o h -l help,file:,filters:,debug -- "$@")
+if [ $? -ne 0 ]; then
+    print_help
+    exit 1
+fi
+eval set -- "$ARGS"
+
+while true; do
+    case $1 in
+        --file)
+            FILE=("${2-}")
+            shift 2
+            ;;
+
+        --filters)
+            FILTERS=("${2-}")
+            shift 2
+            ;;
+
+        --debug)
+            DEBUG=1
+            shift
+            ;;
+
+
+        --)
+            shift
+            break
+            ;;
+
+        --status)
+            print_status
+            exit
+            ;;
+
+        -h|--help|*)
+            print_help
+            exit
+            ;;
+    esac
+done
+
+JSON=$(get_aws_json $FILE)
+
+if [[ -n $FILTERS ]]; then
+    FILTERS=$(build_filters "$FILTERS")
+fi
+
+V4_RANGES=$(extract_ip_ranges "$JSON" "$FILTERS" "prefixes" "ip_prefix")
+V6_RANGES=$(extract_ip_ranges "$JSON" "$FILTERS" "ipv6_prefixes" "ipv6_prefix")
+
+create_ferm_array 4 "$V4_RANGES"
+create_ferm_array 6 "$V6_RANGES"

--- a/functions.sh
+++ b/functions.sh
@@ -1,0 +1,136 @@
+JSON_URL="https://ip-ranges.amazonaws.com/ip-ranges.json"
+
+if [[ -z $DEBUG ]]; then
+    DEBUG=0
+fi
+
+
+function log() {
+    if [[ $DEBUG == 1 ]]; then
+        echo $* >&2
+    fi
+}
+
+
+##
+# Retrieves AWS JSON data
+#
+function get_aws_json() {
+    # Retrieve IP ranges definition
+    # Either from an URL or file input (e.g. "< ranges.json")
+    if [[ -f $1 ]]; then
+        log "Loading IP ranges from file"
+        local json=$(<$1)
+    else
+        log "Downloading IP ranges via curl"
+        local json=$(curl -s -L $JSON_URL)
+    fi
+
+    if [[ -z $json ]]; then
+        echo "JSON definition empty" >&2
+        exit 1
+    fi
+
+    echo "$json"
+}
+
+
+##
+# Builds region filters based on CLI arguments
+#
+# Arguments: CLI arguments as passed by $*
+#
+function build_filters() {
+    for arg in ${@:1}; do
+        if [[ -n $filters ]]; then
+            filters=$filters", "
+        fi
+
+        filters=$filters"select(.region | contains(\"$arg\"))"
+    done
+
+    if [[ -n $filters ]]; then
+        filters=" | "$filters
+    fi
+
+    log "Built filters ('$filters')"
+    echo "$filters"
+}
+
+
+##
+# Extracts IP ranges from an Amazon JSON file
+#
+# Arguments:
+#     $1 AWS JSON content
+#     $2 Prepared filter string
+#     $3 Group to extract IP ranges from (e.g. prefixes)
+#     $4 Object key for IP ranges (e.g ip_prefix)
+#
+function extract_ip_ranges() {
+    local json=$1
+    local filters=$2
+    local array=$3
+    local prefix=$4
+
+    log "Extracting IP ranges ($4)"
+
+    local group='group_by(.'$prefix')'
+    local map='map({ "ip": .[0].'$prefix', "regions": map(.region) | unique, "services": map(.service) | unique })'
+
+    local to_string='.ip + " \"" + (.regions | sort | join (", ")) + "\" \"" + (.services | sort | join (", ")) + "\""'
+    local process='[ .'$array"[]$filters ] | $group | $map | .[] | $to_string"
+
+    local ranges=$(echo "$json" | jq -r "$process" | sort -Vu)
+    echo "$ranges"
+}
+
+
+##
+# Creates the AWS iptables chain if it doesn't exist, then flushes it
+#
+# Arguments:
+#     $1 Version to use. Omit for v4
+#     $2 Position to insert chain statement at
+#
+function create_and_flush_chain() {
+    local version=$1
+    local position=$2
+    local cmd=ip${version}tables
+
+    log "Creating and flushing chain $version"
+
+    $cmd -n --list AWS >/dev/null 2>&1 \
+        || ($cmd -N AWS && $cmd -I INPUT $position -j AWS)
+
+    $cmd -F AWS
+}
+
+
+##
+# Adds an iptables rule for each line in ranges
+#
+# Arguments:
+#     $1 Version to use. Omit for v4
+#     $2 Prepared lines
+#
+function add_iptables_rules() {
+    local version=$1
+    local cmd=ip${version}tables
+    local lines
+    local data
+
+    log "Adding iptables rules $version"
+
+    IFS=$'\n' lines=($2)
+    unset IFS
+
+    for line in "${lines[@]}"; do
+        eval local data=($line)
+        local ip=${data[0]}
+        local regions=$(echo ${data[1]} | tr '[:upper:]' '[:lower:]')
+        local services=$(echo ${data[2]} | tr '[:upper:]' '[:lower:]')
+
+        $cmd -A AWS -s "$ip" -j REJECT -m comment --comment "$regions = $services"
+    done
+}

--- a/functions.sh
+++ b/functions.sh
@@ -134,3 +134,32 @@ function add_iptables_rules() {
         $cmd -A AWS -s "$ip" -j REJECT -m comment --comment "$regions = $services"
     done
 }
+
+
+##
+# Creates a ferm IP definition ruleset.
+#
+# Arguments:
+#     $1 Version to use
+#     $2 Prepared lines
+#
+function create_ferm_array() {
+    local version=$1
+    shift
+
+    echo '@def $AWS_IPS_V'$version' = ('
+
+    IFS=$'\n' lines=($1)
+    unset IFS
+
+    for line in "${lines[@]}"; do
+        eval local data=($line)
+        local ip=${data[0]}
+        local regions=$(echo ${data[1]} | tr '[:upper:]' '[:lower:]')
+        local services=$(echo ${data[2]} | tr '[:upper:]' '[:lower:]')
+
+        echo -e "    $ip\t\t\t# $regions = $services"
+    done
+
+    echo ');'
+}


### PR DESCRIPTION
SSH seems to use pipes, which is bad for detection of file inputs and thus breaks on e.g. Ansible.

This also adds a separate script for ferm-array output.